### PR TITLE
Move command server logging so it will use the right format

### DIFF
--- a/source/Launchpad-Commands/LaunchpadStartApplicationCommand.class.st
+++ b/source/Launchpad-Commands/LaunchpadStartApplicationCommand.class.st
@@ -42,7 +42,6 @@ LaunchpadStartApplicationCommand >> enableStructuredLogging [
 { #category : #configuring }
 LaunchpadStartApplicationCommand >> enableTCPCommandServerListeningOn: listeningPort [
 
-	LaunchpadLogRecord emitInfo: ( 'Receiving commands over TCP/<1p>' expandMacrosWith: listeningPort ).
 	commandServer := TCPCommandServer listeningOn: listeningPort.
 	commandServer registerCommandNamed: 'SHUTDOWN' executing: [ 
 		[ 

--- a/source/Launchpad-Commands/TCPCommandServer.class.st
+++ b/source/Launchpad-Commands/TCPCommandServer.class.st
@@ -60,6 +60,9 @@ TCPCommandServer >> serverLoop [
 { #category : #controlling }
 TCPCommandServer >> start [
 
+	LaunchpadLogRecord emitInfo:
+		( 'Receiving commands over TCP/<1p>' expandMacrosWith: self listeningPort ).
+
 	connectionSocket
 		listenOn: self listeningPort
 		backlogSize: 2


### PR DESCRIPTION
When changing the logging format to use the structured one we need to log this a bit later in the execution, otherwise it will appear in the logs in the non-structured format