### PR TITLE
Update default command line handler to not exit the gem unless specified by the user

### DIFF
--- a/docker/gs64/command-line-handler.tpz
+++ b/docker/gs64/command-line-handler.tpz
@@ -1,7 +1,7 @@
 iferror exit 1
 login
 doit
-  LaunchpadCommandLineHandler activateWith: (CommandLineArguments new copyAfter: '--')
+  LaunchpadCommandLineHandler activateWith: (CommandLineArguments new copyAfter: '--').
   [ Delay waitForMilliseconds: 20 ] repeat.
 %
 exit 0

--- a/docker/gs64/command-line-handler.tpz
+++ b/docker/gs64/command-line-handler.tpz
@@ -2,5 +2,6 @@ iferror exit 1
 login
 doit
   LaunchpadCommandLineHandler activateWith: (CommandLineArguments new copyAfter: '--')
+  [ Delay waitForMilliseconds: 20 ] repeat.
 %
 exit 0


### PR DESCRIPTION
Some applications are forking background processes, and not expecting the main process to terminate. In Launchpad application termination is explicit by calling `exitSuccess` or `exitError`.
This change make the GS64 code compatible with Pharo.