### PR TITLE
Null config for testing

### DIFF
--- a/source/Launchpad-Commands-Tests/LaunchpadZnHelloApplicationTest.class.st
+++ b/source/Launchpad-Commands-Tests/LaunchpadZnHelloApplicationTest.class.st
@@ -1,0 +1,76 @@
+"
+A LaunchpadCommandLineHandlerTest is a test class for testing the behavior of LaunchpadCommandLineHandler
+"
+Class {
+	#name : 'LaunchpadZnHelloApplicationTest',
+	#superclass : 'LaunchpadTest',
+	#category : 'Launchpad-Commands-Tests',
+	#package : 'Launchpad-Commands-Tests'
+}
+
+{ #category : 'tests' }
+LaunchpadZnHelloApplicationTest >> testConfigParsingInValidLogLevel [
+	"Verify the launchpad handler properly handles non numeric input"
+	
+	| application mockContext config |
+	
+	"Test passing a non-numeric log level parameter"
+	config := NullConfigurationProvider new
+		          atName: #'log-level' putValue: 'false';
+		          yourself.
+
+	application := LaunchpadZnHelloApplication 
+		               runningIn: DebuggingApplicationMode new
+		               configuredBy: config
+		               controlledBy: NullCommandServer new.
+
+	"Expect the Launchpad application to handle the error and substitute a loglevel of 0"
+	mockContext := MockObject new
+		               on: #runZnHelloWithPort:debugLevel: 
+		               with: 8181
+							with: 0;
+		               yourself.
+
+	application basicStartWithin: mockContext.
+
+	mockContext verifyIn: self
+]
+
+{ #category : 'tests' }
+LaunchpadZnHelloApplicationTest >> testConfigParsingValidLogLevel [
+	"Verify the launchpad handler correctly parses the paramter to an integer"
+
+	| application mockContext config |
+	
+	config := NullConfigurationProvider new
+		          atName: #'log-level' putValue: '2';
+		          yourself.
+
+	application := LaunchpadZnHelloApplication 
+		               runningIn: DebuggingApplicationMode new
+		               configuredBy: config
+		               controlledBy: NullCommandServer new.
+
+	mockContext := MockObject new
+		               on: #runZnHelloWithPort:debugLevel: 
+		               with: 8181
+							with: 2;
+		               yourself.
+
+	application basicStartWithin: mockContext.
+
+	mockContext verifyIn: self
+]
+
+{ #category : 'tests' }
+LaunchpadZnHelloApplicationTest >> testDryRunApplication [
+
+	self
+		should: [
+			LaunchpadCommandLineHandler activateWithArguments:
+				#( 'launchpad' 'start' '--dry-run' 'znHello' )
+			]
+		raise: Exit
+		withExceptionDo: [ :exit | self assert: exit isSuccess ] 
+
+]

--- a/source/Launchpad-Commands/LaunchpadCommandLineHandler.class.st
+++ b/source/Launchpad-Commands/LaunchpadCommandLineHandler.class.st
@@ -59,5 +59,7 @@ LaunchpadCommandLineHandler >> activateWithContext: context [
 	StandardStreamLogger onStandardError startFor:
 		( LogRecord where: [ :record | record isInformational not ] ).
 
+	LogRecord emitInfo: 'Launchpad processing command line parameters'.
+	
 	^ LaunchpadRootCommand new evaluateWithin: context
 ]

--- a/source/Launchpad-Configuration/ApplicationConfiguration.class.st
+++ b/source/Launchpad-Configuration/ApplicationConfiguration.class.st
@@ -1,25 +1,21 @@
 Class {
-	#name : 'ApplicationConfiguration',
-	#superclass : 'Object',
+	#name : #ApplicationConfiguration,
+	#superclass : #Object,
 	#instVars : [
 		'parameters',
 		'provider',
 		'values'
 	],
-	#category : 'Launchpad-Configuration',
-	#package : 'Launchpad-Configuration',
-	#'gs_options' : [
-		'dbTransient'
-	]
+	#category : 'Launchpad-Configuration'
 }
 
-{ #category : 'instance creation' }
+{ #category : #'instance creation' }
 ApplicationConfiguration class >> forAll: parameters providedBy: aConfigurationProvider [
 
 	^ self new initializeForAll: parameters providedBy: aConfigurationProvider
 ]
 
-{ #category : 'converting' }
+{ #category : #converting }
 ApplicationConfiguration >> asCommandLineOn: stream [
 
 	( parameters sorted: #commandLineArgumentName ascending ) do: [ :parameter | 
@@ -32,7 +28,7 @@ ApplicationConfiguration >> asCommandLineOn: stream [
 		]
 ]
 
-{ #category : 'converting' }
+{ #category : #converting }
 ApplicationConfiguration >> asEnvironmentOn: stream [
 
 	( parameters sorted: #environmentVariableName ascending ) do: [ :parameter | 
@@ -48,7 +44,7 @@ ApplicationConfiguration >> asEnvironmentOn: stream [
 		]
 ]
 
-{ #category : 'private' }
+{ #category : #private }
 ApplicationConfiguration >> asIniFile: aParameterCollection on: stream [
 
 	( aParameterCollection sorted: #attributeName ascending ) do: [ :parameter | 
@@ -66,7 +62,7 @@ ApplicationConfiguration >> asIniFile: aParameterCollection on: stream [
 		]
 ]
 
-{ #category : 'converting' }
+{ #category : #converting }
 ApplicationConfiguration >> asIniFileOn: stream [
 
 	| settingsInSection |
@@ -86,13 +82,13 @@ ApplicationConfiguration >> asIniFileOn: stream [
 		]
 ]
 
-{ #category : 'converting' }
+{ #category : #converting }
 ApplicationConfiguration >> asJson [
 
 	^ String streamContents: [ :stream | self asJsonOn: stream ]
 ]
 
-{ #category : 'converting' }
+{ #category : #converting }
 ApplicationConfiguration >> asJsonOn: stream [
 
 	^ ( NeoJSONWriterSortingKeys on: stream )
@@ -101,7 +97,7 @@ ApplicationConfiguration >> asJsonOn: stream [
 		  nextPut: values
 ]
 
-{ #category : 'private' }
+{ #category : #private }
 ApplicationConfiguration >> assert: section isNotInConflictWithParameterNamed: name [
 
 	"Sections in the configuration are instances of NeoJSONObject, if we get 
@@ -112,7 +108,7 @@ ApplicationConfiguration >> assert: section isNotInConflictWithParameterNamed: n
 		raising: ConflictingObjectFound
 ]
 
-{ #category : 'private' }
+{ #category : #private }
 ApplicationConfiguration >> containingSectionFor: parameter startingAt: resolvedValues [
 
 	| currentSection |
@@ -126,13 +122,13 @@ ApplicationConfiguration >> containingSectionFor: parameter startingAt: resolved
 	^ currentSection
 ]
 
-{ #category : 'reflective operations' }
+{ #category : #'reflective operations' }
 ApplicationConfiguration >> doesNotUnderstand: message [
 
 	^ self valueAt: message selector ifAbsent: [ super doesNotUnderstand: message ]
 ]
 
-{ #category : 'initialization' }
+{ #category : #initialization }
 ApplicationConfiguration >> initializeForAll: aParameterCollection providedBy: aConfigurationProvider [
 
 	parameters := aParameterCollection.
@@ -140,7 +136,7 @@ ApplicationConfiguration >> initializeForAll: aParameterCollection providedBy: a
 	self resolveParameterValues
 ]
 
-{ #category : 'private' }
+{ #category : #private }
 ApplicationConfiguration >> missingConfigurationFor: parameter [
 
 	LogRecord emitError:
@@ -149,20 +145,20 @@ ApplicationConfiguration >> missingConfigurationFor: parameter [
 		( '"<1s>" parameter not present.' expandMacrosWith: parameter name )
 ]
 
-{ #category : 'accessing' }
+{ #category : #accessing }
 ApplicationConfiguration >> parameters [
 
 	^ parameters
 ]
 
-{ #category : 'actions' }
+{ #category : #actions }
 ApplicationConfiguration >> reload [
 
 	provider reloadConfiguration.
 	self resolveParameterValues
 ]
 
-{ #category : 'initialization' }
+{ #category : #initialization }
 ApplicationConfiguration >> resolveParameterValues [
 
 	| section resolvedValues |
@@ -181,31 +177,31 @@ ApplicationConfiguration >> resolveParameterValues [
 	self synchronizeValuesWith: resolvedValues
 ]
 
-{ #category : 'reflective operations' }
+{ #category : #'reflective operations' }
 ApplicationConfiguration >> respondsTo: selector [
 
 	^ ( super respondsTo: selector ) or: [ values includesKey: selector ]
 ]
 
-{ #category : 'private' }
+{ #category : #private }
 ApplicationConfiguration >> signalAsConflictingParameter: parameter [
 
 	ConflictingObjectFound signal: ( 'Conflicting parameter: "<1s>"' expandMacrosWith: parameter name )
 ]
 
-{ #category : 'private' }
+{ #category : #private }
 ApplicationConfiguration >> synchronizeValuesWith: resolvedValues [
 
 	values := resolvedValues
 ]
 
-{ #category : 'accessing' }
+{ #category : #accessing }
 ApplicationConfiguration >> valueAt: aKey [
 
 	^ self valueAt: aKey ifAbsent: [ KeyNotFound signalFor: aKey ]
 ]
 
-{ #category : 'accessing' }
+{ #category : #accessing }
 ApplicationConfiguration >> valueAt: aKey ifAbsent: aBlock [
 	"For configuration access without DNU handling, provide standard Dictionary api. 
 	With normal configuration parameters, there should never be an absent value, but provide the standard ifAbsent option for correctness"
@@ -213,7 +209,7 @@ ApplicationConfiguration >> valueAt: aKey ifAbsent: aBlock [
 	^ values at: aKey ifAbsent: aBlock
 ]
 
-{ #category : 'accessing' }
+{ #category : #accessing }
 ApplicationConfiguration >> valueFor: aParameter [
 
 	| section |

--- a/source/Launchpad-Configuration/ConfigurationFromCommandLineProvider.class.st
+++ b/source/Launchpad-Configuration/ConfigurationFromCommandLineProvider.class.st
@@ -1,40 +1,39 @@
 Class {
-	#name : 'ConfigurationFromCommandLineProvider',
-	#superclass : 'ConfigurationProvider',
+	#name : #ConfigurationFromCommandLineProvider,
+	#superclass : #ConfigurationProvider,
 	#instVars : [
 		'commandLine',
 		'nextProvider'
 	],
-	#category : 'Launchpad-Configuration',
-	#package : 'Launchpad-Configuration'
+	#category : 'Launchpad-Configuration'
 }
 
-{ #category : 'instance creation' }
+{ #category : #'instance creation' }
 ConfigurationFromCommandLineProvider class >> over: aCommandLine [
 
 	^ self over: aCommandLine chainedWith: NullConfigurationProvider new
 ]
 
-{ #category : 'instance creation' }
+{ #category : #'instance creation' }
 ConfigurationFromCommandLineProvider class >> over: aCommandLine chainedWith: aConfigurationProvider [
 
 	^ self new initializeOver: aCommandLine chainedWith: aConfigurationProvider
 ]
 
-{ #category : 'initialization' }
+{ #category : #initialization }
 ConfigurationFromCommandLineProvider >> initializeOver: aCommandLine chainedWith: aConfigurationProvider [
 
 	commandLine := aCommandLine.
 	nextProvider := aConfigurationProvider
 ]
 
-{ #category : 'initialization' }
+{ #category : #initialization }
 ConfigurationFromCommandLineProvider >> reloadConfiguration [
 
 	nextProvider reloadConfiguration
 ]
 
-{ #category : 'resolving' }
+{ #category : #resolving }
 ConfigurationFromCommandLineProvider >> valueFor: aConfigurationParameter ifFound: aPresentBlock ifNone: aFailBlock [
 
 	^ commandLine optionAt: aConfigurationParameter commandLineArgumentName

--- a/source/Launchpad-Configuration/ConfigurationFromEnvironmentProvider.class.st
+++ b/source/Launchpad-Configuration/ConfigurationFromEnvironmentProvider.class.st
@@ -1,38 +1,37 @@
 Class {
-	#name : 'ConfigurationFromEnvironmentProvider',
-	#superclass : 'ConfigurationProvider',
+	#name : #ConfigurationFromEnvironmentProvider,
+	#superclass : #ConfigurationProvider,
 	#instVars : [
 		'nextProvider'
 	],
-	#category : 'Launchpad-Configuration',
-	#package : 'Launchpad-Configuration'
+	#category : 'Launchpad-Configuration'
 }
 
-{ #category : 'instance creation' }
+{ #category : #'instance creation' }
 ConfigurationFromEnvironmentProvider class >> chainedWith: aConfigurationProvider [
 
 	^ super new initializeChainedWith: aConfigurationProvider
 ]
 
-{ #category : 'instance creation' }
+{ #category : #'instance creation' }
 ConfigurationFromEnvironmentProvider class >> new [
 
 	^ self chainedWith: NullConfigurationProvider new
 ]
 
-{ #category : 'initialization' }
+{ #category : #initialization }
 ConfigurationFromEnvironmentProvider >> initializeChainedWith: aConfigurationProvider [
 
 	nextProvider := aConfigurationProvider
 ]
 
-{ #category : 'initialization' }
+{ #category : #initialization }
 ConfigurationFromEnvironmentProvider >> reloadConfiguration [
 
 	^ nextProvider reloadConfiguration
 ]
 
-{ #category : 'resolving' }
+{ #category : #resolving }
 ConfigurationFromEnvironmentProvider >> valueFor: aConfigurationParameter ifFound: aPresentBlock ifNone: aFailBlock [
 
 	^ LanguagePlatform current os

--- a/source/Launchpad-Configuration/ConfigurationFromIniSettingsFileProvider.class.st
+++ b/source/Launchpad-Configuration/ConfigurationFromIniSettingsFileProvider.class.st
@@ -1,28 +1,27 @@
 Class {
-	#name : 'ConfigurationFromIniSettingsFileProvider',
-	#superclass : 'ConfigurationFromSettingsFileProvider',
+	#name : #ConfigurationFromIniSettingsFileProvider,
+	#superclass : #ConfigurationFromSettingsFileProvider,
 	#instVars : [
 		'fileReference',
 		'iniData',
 		'nextProvider'
 	],
-	#category : 'Launchpad-Configuration',
-	#package : 'Launchpad-Configuration'
+	#category : 'Launchpad-Configuration'
 }
 
-{ #category : 'testing' }
+{ #category : #testing }
 ConfigurationFromIniSettingsFileProvider class >> canHandle: aFileReference [
 
 	^ aFileReference extension = 'ini'
 ]
 
-{ #category : 'instance creation' }
+{ #category : #'instance creation' }
 ConfigurationFromIniSettingsFileProvider class >> loading: anIniFileReference chainedWith: aConfigurationProvider [
 
 	^ self new initializeLoading: anIniFileReference chainedWith: aConfigurationProvider
 ]
 
-{ #category : 'initialization' }
+{ #category : #initialization }
 ConfigurationFromIniSettingsFileProvider >> initializeLoading: aFileReference chainedWith: aConfigurationProvider [
 
 	fileReference := aFileReference.
@@ -30,20 +29,20 @@ ConfigurationFromIniSettingsFileProvider >> initializeLoading: aFileReference ch
 	nextProvider := aConfigurationProvider
 ]
 
-{ #category : 'initialization' }
+{ #category : #initialization }
 ConfigurationFromIniSettingsFileProvider >> loadConfiguration [
 
 	fileReference readStreamDo: [ :stream | iniData := ( IniReader on: stream ) parse ]
 ]
 
-{ #category : 'initialization' }
+{ #category : #initialization }
 ConfigurationFromIniSettingsFileProvider >> reloadConfiguration [
 
 	self loadConfiguration.
 	nextProvider reloadConfiguration
 ]
 
-{ #category : 'resolving' }
+{ #category : #resolving }
 ConfigurationFromIniSettingsFileProvider >> valueFor: aConfigurationParameter ifFound: aPresentBlock ifNone: aFailBlock [
 
 	^ iniData

--- a/source/Launchpad-Configuration/ConfigurationFromJsonSettingsFileProvider.class.st
+++ b/source/Launchpad-Configuration/ConfigurationFromJsonSettingsFileProvider.class.st
@@ -1,35 +1,34 @@
 Class {
-	#name : 'ConfigurationFromJsonSettingsFileProvider',
-	#superclass : 'ConfigurationFromSettingsFileProvider',
+	#name : #ConfigurationFromJsonSettingsFileProvider,
+	#superclass : #ConfigurationFromSettingsFileProvider,
 	#instVars : [
 		'fileReference',
 		'json',
 		'nextProvider'
 	],
-	#category : 'Launchpad-Configuration',
-	#package : 'Launchpad-Configuration'
+	#category : 'Launchpad-Configuration'
 }
 
-{ #category : 'testing' }
+{ #category : #testing }
 ConfigurationFromJsonSettingsFileProvider class >> canHandle: aFileReference [
 
 	^ aFileReference extension = 'json'
 ]
 
-{ #category : 'instance creation' }
+{ #category : #'instance creation' }
 ConfigurationFromJsonSettingsFileProvider class >> loading: aJsonFileReference chainedWith: aConfigurationProvider [
 
 	^ self new initializeLoading: aJsonFileReference chainedWith: aConfigurationProvider
 ]
 
-{ #category : 'private' }
+{ #category : #private }
 ConfigurationFromJsonSettingsFileProvider >> asJsonPath: aConfigurationParameter [
 
 	^ (aConfigurationParameter sectionsAsAttributeNames copyWith:
 		   aConfigurationParameter attributeName) collect: #asSymbol
 ]
 
-{ #category : 'initialization' }
+{ #category : #initialization }
 ConfigurationFromJsonSettingsFileProvider >> initializeLoading: aFileReference chainedWith: aConfigurationProvider [
 
 	fileReference := aFileReference.
@@ -37,21 +36,21 @@ ConfigurationFromJsonSettingsFileProvider >> initializeLoading: aFileReference c
 	nextProvider := aConfigurationProvider
 ]
 
-{ #category : 'initialization' }
+{ #category : #initialization }
 ConfigurationFromJsonSettingsFileProvider >> loadConfiguration [
 
 	json := [ NeoJSONObject fromString: fileReference contents ] on: NeoJSONParseError
 		        do: [ :error | error return: NeoJSONObject new ]
 ]
 
-{ #category : 'initialization' }
+{ #category : #initialization }
 ConfigurationFromJsonSettingsFileProvider >> reloadConfiguration [
 
 	self loadConfiguration.
 	nextProvider reloadConfiguration
 ]
 
-{ #category : 'resolving' }
+{ #category : #resolving }
 ConfigurationFromJsonSettingsFileProvider >> valueFor: aConfigurationParameter ifFound: aPresentBlock ifNone: aFailBlock [
 
 	^ (json atPath: (self asJsonPath: aConfigurationParameter))

--- a/source/Launchpad-Configuration/ConfigurationFromSettingsFileProvider.class.st
+++ b/source/Launchpad-Configuration/ConfigurationFromSettingsFileProvider.class.st
@@ -1,30 +1,29 @@
 Class {
-	#name : 'ConfigurationFromSettingsFileProvider',
-	#superclass : 'ConfigurationProvider',
-	#category : 'Launchpad-Configuration',
-	#package : 'Launchpad-Configuration'
+	#name : #ConfigurationFromSettingsFileProvider,
+	#superclass : #ConfigurationProvider,
+	#category : 'Launchpad-Configuration'
 }
 
-{ #category : 'testing' }
+{ #category : #testing }
 ConfigurationFromSettingsFileProvider class >> canHandle: aFileReference [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : 'testing' }
+{ #category : #testing }
 ConfigurationFromSettingsFileProvider class >> isAbstract [
 
 	<ignoreForCoverage>
 	^ self = ConfigurationFromSettingsFileProvider
 ]
 
-{ #category : 'instance creation' }
+{ #category : #'instance creation' }
 ConfigurationFromSettingsFileProvider class >> loading: aFileReference [
 
 	^ self loading: aFileReference chainedWith: NullConfigurationProvider new
 ]
 
-{ #category : 'instance creation' }
+{ #category : #'instance creation' }
 ConfigurationFromSettingsFileProvider class >> loading: aFileReference chainedWith: aConfigurationProvider [
 
 	^ self subclasses detect: [ :providerClass | providerClass canHandle: aFileReference ]

--- a/source/Launchpad-Configuration/ConfigurationParameter.class.st
+++ b/source/Launchpad-Configuration/ConfigurationParameter.class.st
@@ -1,11 +1,10 @@
 Class {
-	#name : 'ConfigurationParameter',
-	#superclass : 'Object',
-	#category : 'Launchpad-Configuration',
-	#package : 'Launchpad-Configuration'
+	#name : #ConfigurationParameter,
+	#superclass : #Object,
+	#category : 'Launchpad-Configuration'
 }
 
-{ #category : 'private - asserting' }
+{ #category : #'private - asserting' }
 ConfigurationParameter class >> assertNotEmpty: aName and: aDescription [
 
 	AssertionCheckerBuilder new
@@ -18,14 +17,14 @@ ConfigurationParameter class >> assertNotEmpty: aName and: aDescription [
 		buildAndCheck
 ]
 
-{ #category : 'testing' }
+{ #category : #testing }
 ConfigurationParameter class >> isAbstract [
 
 	<ignoreForCoverage>
 	^ self = ConfigurationParameter
 ]
 
-{ #category : 'accessing' }
+{ #category : #accessing }
 ConfigurationParameter >> asAttributeName: string [
 
 	| parts |
@@ -35,7 +34,7 @@ ConfigurationParameter >> asAttributeName: string [
 		    parts allButFirstDo: [ :word | stream nextPutAll: word capitalized ] ] )
 ]
 
-{ #category : 'accessing' }
+{ #category : #accessing }
 ConfigurationParameter >> asIniFileSection [
 
 	^ String streamContents: [ :stream | 
@@ -44,7 +43,7 @@ ConfigurationParameter >> asIniFileSection [
 		  ]
 ]
 
-{ #category : 'accessing' }
+{ #category : #accessing }
 ConfigurationParameter >> asIniFileSectionName: string [
 
 	^ string collect: [ :character | 
@@ -53,19 +52,19 @@ ConfigurationParameter >> asIniFileSectionName: string [
 		  ]
 ]
 
-{ #category : 'converting' }
+{ #category : #converting }
 ConfigurationParameter >> asSensitive [
 
 	^ SensitiveConfigurationParameter over: self
 ]
 
-{ #category : 'accessing' }
+{ #category : #accessing }
 ConfigurationParameter >> attributeName [
 
 	^ self asAttributeName: self name
 ]
 
-{ #category : 'accessing' }
+{ #category : #accessing }
 ConfigurationParameter >> commandLineArgumentName [
 
 	| transformer |
@@ -86,7 +85,7 @@ ConfigurationParameter >> commandLineArgumentName [
 		  ]
 ]
 
-{ #category : 'accessing' }
+{ #category : #accessing }
 ConfigurationParameter >> environmentVariableName [
 
 	| transformer |
@@ -107,50 +106,50 @@ ConfigurationParameter >> environmentVariableName [
 		  ]
 ]
 
-{ #category : 'logging' }
+{ #category : #logging }
 ConfigurationParameter >> logValueIn: configuration [
 
 	LogRecord emitInfo:
 		( '<1s>: <2s>' expandMacrosWith: self name with: ( self valueToLogFrom: configuration ) asString )
 ]
 
-{ #category : 'accessing' }
+{ #category : #accessing }
 ConfigurationParameter >> name [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : 'printing' }
+{ #category : #printing }
 ConfigurationParameter >> printAsCommandLineArgumentTemplateOn: stream [
 
 	self subclassResponsibility
 ]
 
-{ #category : 'resolving' }
+{ #category : #resolving }
 ConfigurationParameter >> resolveValueUsing: aConfigurationProvider ifUnable: aBlock [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : 'accessing' }
+{ #category : #accessing }
 ConfigurationParameter >> sections [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : 'accessing' }
+{ #category : #accessing }
 ConfigurationParameter >> sectionsAsAttributeNames [
 
 	^ self sections collect: [ :section | self asAttributeName: section ]
 ]
 
-{ #category : 'accessing' }
+{ #category : #accessing }
 ConfigurationParameter >> summary [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : 'logging' }
+{ #category : #logging }
 ConfigurationParameter >> valueToLogFrom: configuration [
 
 	^ configuration valueFor: self

--- a/source/Launchpad-Configuration/ConfigurationProvider.class.st
+++ b/source/Launchpad-Configuration/ConfigurationProvider.class.st
@@ -1,24 +1,23 @@
 Class {
-	#name : 'ConfigurationProvider',
-	#superclass : 'Object',
-	#category : 'Launchpad-Configuration',
-	#package : 'Launchpad-Configuration'
+	#name : #ConfigurationProvider,
+	#superclass : #Object,
+	#category : 'Launchpad-Configuration'
 }
 
-{ #category : 'testing' }
+{ #category : #testing }
 ConfigurationProvider class >> isAbstract [
 
 	<ignoreForCoverage>
 	^ self =  ConfigurationProvider
 ]
 
-{ #category : 'initialization' }
+{ #category : #initialization }
 ConfigurationProvider >> reloadConfiguration [
 
 	self subclassResponsibility
 ]
 
-{ #category : 'resolving' }
+{ #category : #resolving }
 ConfigurationProvider >> valueFor: aConfigurationParameter ifFound: aPresentBlock ifNone: aFailBlock [
 
 	self subclassResponsibility

--- a/source/Launchpad-Configuration/MandatoryConfigurationParameter.class.st
+++ b/source/Launchpad-Configuration/MandatoryConfigurationParameter.class.st
@@ -1,23 +1,22 @@
 Class {
-	#name : 'MandatoryConfigurationParameter',
-	#superclass : 'ConfigurationParameter',
+	#name : #MandatoryConfigurationParameter,
+	#superclass : #ConfigurationParameter,
 	#instVars : [
 		'name',
 		'summary',
 		'sections',
 		'converter'
 	],
-	#category : 'Launchpad-Configuration',
-	#package : 'Launchpad-Configuration'
+	#category : 'Launchpad-Configuration'
 }
 
-{ #category : 'instance creation' }
+{ #category : #'instance creation' }
 MandatoryConfigurationParameter class >> named: aName describedBy: aDescription [
 
 	^ self named: aName describedBy: aDescription inside: #(  )
 ]
 
-{ #category : 'instance creation' }
+{ #category : #'instance creation' }
 MandatoryConfigurationParameter class >> named: aName describedBy: aDescription convertingWith: aConverterAction [
 
 	^ self named: aName
@@ -26,7 +25,7 @@ MandatoryConfigurationParameter class >> named: aName describedBy: aDescription 
 		  convertingWith: aConverterAction
 ]
 
-{ #category : 'instance creation' }
+{ #category : #'instance creation' }
 MandatoryConfigurationParameter class >> named: aName describedBy: aDescription inside: aSectionCollection [
 
 	^ self named: aName
@@ -35,7 +34,7 @@ MandatoryConfigurationParameter class >> named: aName describedBy: aDescription 
 		  convertingWith: #yourself
 ]
 
-{ #category : 'instance creation' }
+{ #category : #'instance creation' }
 MandatoryConfigurationParameter class >> named: aName describedBy: aDescription inside: aSectionCollection convertingWith: aConverterAction [
 
 	self assertNotEmpty: aName and: aDescription.
@@ -46,7 +45,7 @@ MandatoryConfigurationParameter class >> named: aName describedBy: aDescription 
 		  convertingWith: aConverterAction
 ]
 
-{ #category : 'initialization' }
+{ #category : #initialization }
 MandatoryConfigurationParameter >> initializeNamed: aName describedBy: aDescription inside: aSectionCollection convertingWith: aConverterAction [
 
 	name := aName.
@@ -55,13 +54,13 @@ MandatoryConfigurationParameter >> initializeNamed: aName describedBy: aDescript
 	converter := aConverterAction
 ]
 
-{ #category : 'accessing' }
+{ #category : #accessing }
 MandatoryConfigurationParameter >> name [
 
 	^ name
 ]
 
-{ #category : 'printing' }
+{ #category : #printing }
 MandatoryConfigurationParameter >> printAsCommandLineArgumentTemplateOn: stream [
 
 	stream
@@ -72,7 +71,7 @@ MandatoryConfigurationParameter >> printAsCommandLineArgumentTemplateOn: stream 
 		nextPutAll: '>'
 ]
 
-{ #category : 'printing' }
+{ #category : #printing }
 MandatoryConfigurationParameter >> printOn: stream [
 
 	stream
@@ -86,19 +85,19 @@ MandatoryConfigurationParameter >> printOn: stream [
 		nextPut: $.
 ]
 
-{ #category : 'resolving' }
+{ #category : #resolving }
 MandatoryConfigurationParameter >> resolveValueUsing: aConfigurationProvider ifUnable: aBlock [
 
 	^ aConfigurationProvider valueFor: self ifFound: converter ifNone: aBlock
 ]
 
-{ #category : 'accessing' }
+{ #category : #accessing }
 MandatoryConfigurationParameter >> sections [
 
 	^ sections
 ]
 
-{ #category : 'accessing' }
+{ #category : #accessing }
 MandatoryConfigurationParameter >> summary [
 
 	^ summary

--- a/source/Launchpad-Configuration/NeoJSONWriterSortingKeys.class.st
+++ b/source/Launchpad-Configuration/NeoJSONWriterSortingKeys.class.st
@@ -1,11 +1,10 @@
 Class {
-	#name : 'NeoJSONWriterSortingKeys',
-	#superclass : 'NeoJSONWriter',
-	#category : 'Launchpad-Configuration',
-	#package : 'Launchpad-Configuration'
+	#name : #NeoJSONWriterSortingKeys,
+	#superclass : #NeoJSONWriter,
+	#category : 'Launchpad-Configuration'
 }
 
-{ #category : 'writing' }
+{ #category : #writing }
 NeoJSONWriterSortingKeys >> writeMap: keyValueCollection [
 
 	self writeMapStreamingDo: [ :jsonMapWriter | 

--- a/source/Launchpad-Configuration/NullConfigurationProvider.class.st
+++ b/source/Launchpad-Configuration/NullConfigurationProvider.class.st
@@ -1,18 +1,33 @@
 Class {
-	#name : 'NullConfigurationProvider',
-	#superclass : 'ConfigurationProvider',
-	#category : 'Launchpad-Configuration',
-	#package : 'Launchpad-Configuration'
+	#name : #NullConfigurationProvider,
+	#superclass : #ConfigurationProvider,
+	#instVars : [
+		'configurationValues'
+	],
+	#category : #'Launchpad-Configuration'
 }
 
-{ #category : 'initialization' }
+{ #category : #resolving }
+NullConfigurationProvider >> atName: aConfigurationParameter putValue: aValue [
+
+	configurationValues at: aConfigurationParameter put: aValue 
+]
+
+{ #category : #initialization }
+NullConfigurationProvider >> initialize [
+	"Subclasses should redefine this method to perform initializations on instance creation"
+	
+	configurationValues := Dictionary new.
+]
+
+{ #category : #initialization }
 NullConfigurationProvider >> reloadConfiguration [
 
 	
 ]
 
-{ #category : 'resolving' }
+{ #category : #resolving }
 NullConfigurationProvider >> valueFor: aConfigurationParameter ifFound: aFoundBlock ifNone: aFailBlock [
 
-	^ aFailBlock value
+	^ configurationValues at: aConfigurationParameter name ifPresent: aFoundBlock ifAbsent: aFailBlock
 ]

--- a/source/Launchpad-Configuration/OptionalConfigurationParameter.class.st
+++ b/source/Launchpad-Configuration/OptionalConfigurationParameter.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : 'OptionalConfigurationParameter',
-	#superclass : 'ConfigurationParameter',
+	#name : #OptionalConfigurationParameter,
+	#superclass : #ConfigurationParameter,
 	#instVars : [
 		'name',
 		'summary',
@@ -9,11 +9,10 @@ Class {
 		'default',
 		'emitWarningAction'
 	],
-	#category : 'Launchpad-Configuration',
-	#package : 'Launchpad-Configuration'
+	#category : 'Launchpad-Configuration'
 }
 
-{ #category : 'instance creation' }
+{ #category : #'instance creation' }
 OptionalConfigurationParameter class >> named: aName describedBy: aDescription defaultingTo: aDefaultValue [
 
 	^ self named: aName
@@ -22,7 +21,7 @@ OptionalConfigurationParameter class >> named: aName describedBy: aDescription d
 		  convertingWith: #yourself
 ]
 
-{ #category : 'instance creation' }
+{ #category : #'instance creation' }
 OptionalConfigurationParameter class >> named: aName describedBy: aDescription defaultingTo: aDefaultValue convertingWith: aConverterAction [
 
 	^ self named: aName
@@ -32,7 +31,7 @@ OptionalConfigurationParameter class >> named: aName describedBy: aDescription d
 		  convertingWith: aConverterAction
 ]
 
-{ #category : 'instance creation' }
+{ #category : #'instance creation' }
 OptionalConfigurationParameter class >> named: aName describedBy: aDescription inside: aSectionCollection defaultingTo: aDefaultValue [
 
 	^ self named: aName
@@ -42,7 +41,7 @@ OptionalConfigurationParameter class >> named: aName describedBy: aDescription i
 		  convertingWith: #yourself
 ]
 
-{ #category : 'instance creation' }
+{ #category : #'instance creation' }
 OptionalConfigurationParameter class >> named: aName describedBy: aDescription inside: aSectionCollection defaultingTo: aDefaultValue convertingWith: aConverterAction [
 
 	self assertNotEmpty: aName and: aDescription.
@@ -53,13 +52,13 @@ OptionalConfigurationParameter class >> named: aName describedBy: aDescription i
 		  convertingWith: aConverterAction
 ]
 
-{ #category : 'configuring' }
+{ #category : #configuring }
 OptionalConfigurationParameter >> doNotWarnWhenUsingDefault [
 
 	emitWarningAction := [  ]
 ]
 
-{ #category : 'initialization' }
+{ #category : #initialization }
 OptionalConfigurationParameter >> initializeNamed: aName describedBy: aDescription inside: aSectionCollection defaultingTo: aDefaultValue convertingWith: aConverterAction [
 
 	name := aName.
@@ -73,13 +72,13 @@ OptionalConfigurationParameter >> initializeNamed: aName describedBy: aDescripti
 	                 ]
 ]
 
-{ #category : 'accessing' }
+{ #category : #accessing }
 OptionalConfigurationParameter >> name [
 
 	^ name
 ]
 
-{ #category : 'printing' }
+{ #category : #printing }
 OptionalConfigurationParameter >> printAsCommandLineArgumentTemplateOn: stream [
 
 	stream
@@ -90,7 +89,7 @@ OptionalConfigurationParameter >> printAsCommandLineArgumentTemplateOn: stream [
 		nextPutAll: '>]'
 ]
 
-{ #category : 'printing' }
+{ #category : #printing }
 OptionalConfigurationParameter >> printOn: stream [
 
 	stream
@@ -104,7 +103,7 @@ OptionalConfigurationParameter >> printOn: stream [
 		nextPut: $.
 ]
 
-{ #category : 'resolving' }
+{ #category : #resolving }
 OptionalConfigurationParameter >> resolveValueUsing: aConfigurationProvider ifUnable: aBlock [
 
 	^ aConfigurationProvider valueFor: self ifFound: converter ifNone: [ 
@@ -113,13 +112,13 @@ OptionalConfigurationParameter >> resolveValueUsing: aConfigurationProvider ifUn
 		  ]
 ]
 
-{ #category : 'accessing' }
+{ #category : #accessing }
 OptionalConfigurationParameter >> sections [
 
 	^ sections
 ]
 
-{ #category : 'accessing' }
+{ #category : #accessing }
 OptionalConfigurationParameter >> summary [
 
 	^ '<1s>. Defaults to <2s>' expandMacrosWith: summary with: ( default = '' ifTrue: [ 'nothing' ]

--- a/source/Launchpad-Configuration/RequiredConfigurationNotFound.class.st
+++ b/source/Launchpad-Configuration/RequiredConfigurationNotFound.class.st
@@ -1,6 +1,5 @@
 Class {
-	#name : 'RequiredConfigurationNotFound',
-	#superclass : 'Error',
-	#category : 'Launchpad-Configuration',
-	#package : 'Launchpad-Configuration'
+	#name : #RequiredConfigurationNotFound,
+	#superclass : #Error,
+	#category : 'Launchpad-Configuration'
 }

--- a/source/Launchpad-Configuration/SensitiveConfigurationParameter.class.st
+++ b/source/Launchpad-Configuration/SensitiveConfigurationParameter.class.st
@@ -1,68 +1,67 @@
 Class {
-	#name : 'SensitiveConfigurationParameter',
-	#superclass : 'ConfigurationParameter',
+	#name : #SensitiveConfigurationParameter,
+	#superclass : #ConfigurationParameter,
 	#instVars : [
 		'parameter'
 	],
-	#category : 'Launchpad-Configuration',
-	#package : 'Launchpad-Configuration'
+	#category : 'Launchpad-Configuration'
 }
 
-{ #category : 'instance creation' }
+{ #category : #'instance creation' }
 SensitiveConfigurationParameter class >> over: aConfigurationParameter [
 
 	^ self new initializeOver: aConfigurationParameter
 ]
 
-{ #category : 'converting' }
+{ #category : #converting }
 SensitiveConfigurationParameter >> asSensitive [
 
 	^ self
 ]
 
-{ #category : 'initialization' }
+{ #category : #initialization }
 SensitiveConfigurationParameter >> initializeOver: aConfigurationParameter [
 
 	parameter := aConfigurationParameter
 ]
 
-{ #category : 'accessing' }
+{ #category : #accessing }
 SensitiveConfigurationParameter >> name [
 
 	^ parameter name
 ]
 
-{ #category : 'printing' }
+{ #category : #printing }
 SensitiveConfigurationParameter >> printAsCommandLineArgumentTemplateOn: stream [
 
 	parameter printAsCommandLineArgumentTemplateOn: stream
 ]
 
-{ #category : 'printing' }
+{ #category : #printing }
 SensitiveConfigurationParameter >> printOn: stream [
 
 	parameter printOn: stream
 ]
 
-{ #category : 'resolving' }
+{ #category : #resolving }
 SensitiveConfigurationParameter >> resolveValueUsing: aConfigurationProvider ifUnable: aBlock [
 
 	^ parameter resolveValueUsing: aConfigurationProvider ifUnable: aBlock
 ]
 
-{ #category : 'accessing' }
+{ #category : #accessing }
 SensitiveConfigurationParameter >> sections [
 
 	^ parameter sections
 ]
 
-{ #category : 'accessing' }
+{ #category : #accessing }
 SensitiveConfigurationParameter >> summary [
 
 	^ parameter summary
 ]
 
-{ #category : 'logging' }
+{ #category : #logging }
 SensitiveConfigurationParameter >> valueToLogFrom: configuration [
 
 	^ '**********'

--- a/source/Launchpad-Configuration/package.st
+++ b/source/Launchpad-Configuration/package.st
@@ -1,1 +1,1 @@
-Package { #name : 'Launchpad-Configuration' }
+Package { #name : #'Launchpad-Configuration' }

--- a/source/Launchpad-Examples/LaunchpadApplicationContext.extension.st
+++ b/source/Launchpad-Examples/LaunchpadApplicationContext.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : 'LaunchpadApplicationContext' }
+
+{ #category : '*Launchpad-Examples' }
+LaunchpadApplicationContext >> runZnHelloWithPort: portNumber debugLevel: debugLevel [
+	"Context extension that allows easy launchpad parameter testing"
+	
+	LaunchpadZnHelloApplication startServerOn: portNumber debug: debugLevel 
+]

--- a/source/Launchpad-Examples/LaunchpadZnHelloApplication.class.st
+++ b/source/Launchpad-Examples/LaunchpadZnHelloApplication.class.st
@@ -1,0 +1,100 @@
+"
+Small example Zinc server application to demonstrate Launchpad with tiny web server example
+"
+Class {
+	#name : 'LaunchpadZnHelloApplication',
+	#superclass : 'LaunchpadApplication',
+	#category : 'Launchpad-Examples',
+	#package : 'Launchpad-Examples'
+}
+
+{ #category : 'accessing' }
+LaunchpadZnHelloApplication class >> commandName [
+
+	^ 'znHello'
+]
+
+{ #category : 'private - accessing' }
+LaunchpadZnHelloApplication class >> configurationParameters [
+
+	^ {
+		  (OptionalConfigurationParameter
+			   named: #'log-level'
+			   describedBy: 'Log http requests level'
+			   defaultingTo: 0).
+
+		  (OptionalConfigurationParameter
+			   named: #port
+			   describedBy: 'Server port'
+			   defaultingTo: 8181) }
+]
+
+{ #category : 'accessing' }
+LaunchpadZnHelloApplication class >> description [
+
+	^ 'Launchpad demo zinc http application'
+]
+
+{ #category : 'example' }
+LaunchpadZnHelloApplication class >> startServer [
+	<script>
+	"This would really be in its own server class, but here to demonstrate a simple example of a running application to start via the command line.
+	eg using: launchpad start ZnHello --log-level=2"
+
+	self startServerOn: 8181 debug: true
+]
+
+{ #category : 'example' }
+LaunchpadZnHelloApplication class >> startServerOn: port debug: debug [ 
+	"This would really be in its own server class, but here to demonstrate a simple example"
+
+	| server |
+	server := (ZnServer defaultOn: port).
+	debug ifTrue: [ server logToTranscript ].
+	server start.
+]
+
+{ #category : 'example' }
+LaunchpadZnHelloApplication class >> stopServer [
+	<script>
+	"This would really be in its own server class, but here to demonstrate a simple example"
+
+	ZnServer default stop
+]
+
+{ #category : 'accessing' }
+LaunchpadZnHelloApplication class >> version [
+
+	^ 'v1.0.0'
+]
+
+{ #category : 'private - activation' }
+LaunchpadZnHelloApplication >> basicStartWithin: context [
+	"This is an example of a launcher using a testable #run:withArguments: pattern. See the example test "
+
+	| debugLevel serverPort |
+	
+	debugLevel := [(self configuration valueAt: #'log-level') asNumber] on: Error do: [ 0 ].
+	serverPort := (self configuration valueAt: #port) asInteger.
+
+	"This would be something to call for your own application class to allow testing"
+	context runZnHelloWithPort: serverPort debugLevel: debugLevel
+]
+
+{ #category : 'accessing' }
+LaunchpadZnHelloApplication >> name [
+
+	^ self configuration name
+]
+
+{ #category : 'error handling' }
+LaunchpadZnHelloApplication >> stackTraceDumper [
+
+	^ NullStackTraceDumper new
+]
+
+{ #category : 'accessing' }
+LaunchpadZnHelloApplication >> title [
+
+	^ self configuration title
+]


### PR DESCRIPTION
Simple proposal to slightly extend the NullConfigurationProvider with at:put: functionality so its easy to write tests for launchpad parameter conversion. Also has an example web server demonstrating a test.

While I could subclass NullConfigurationProvider in my own code, I'm hoping this change is non-controversial and hopefully shows others how they could easily write a similar test.

Understand if you prefer not to include this (and I can make my own subclass) but thought it might be interesting enough to include.

p.s. sorry for the extra changes - the change from P11 to P12 for category format type is annoying.