### PR TITLE
chore(ci): ignore ba-st-actions/pharo-ci in dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    ignore:
+      - dependency-name: "ba-st-actions/pharo-ci"
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
Multiple versions are pinned intentionally to run CI against all supported Pharo releases.
Fixes #92