### PR TITLE
docs: fix several documentation issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,5 +117,5 @@ Documentation lives in the `docs/` folder, licensed under CC BY-SA 4.0., and org
 | --- | --- |
 | `docs/how-to/` | Step-by-step guides for accomplishing specific tasks |
 | `docs/reference/` | Reference material (APIs, configuration options, etc.) |
-| `docs/tutorials/` | Learning-oriented walkthroughs for newcomers |
-| `docs/explanations/` | Clarifications and in-depth discussions of concepts |
+| `docs/tutorial/` | Learning-oriented walkthroughs for newcomers |
+| `docs/explanation/` | Clarifications and in-depth discussions of concepts |

--- a/docs/how-to/how-to-use-as-dependency-in-pharo.md
+++ b/docs/how-to/how-to-use-as-dependency-in-pharo.md
@@ -16,7 +16,7 @@ the package in your product baseline:
 
       spec
         baseline: 'Launchpad'
-        with: [ spec repository: 'github://github://ba-st/Launchpad:v{XX}' ];
+        with: [ spec repository: 'github://ba-st/Launchpad:v{XX}' ];
         project: 'Launchpad-Deployment'
         copyFrom: 'Launchpad' with: [ spec loads: 'Deployment' ]
     ```

--- a/docs/reference/CLI.md
+++ b/docs/reference/CLI.md
@@ -248,7 +248,9 @@ $ launchpad start greeter
                 launchpad-start - Start the selected application
   SYNOPSYS
                 launchpad start [--help|-h] [--debug-mode]
-                  [--settings-file=<filename>] [--dry-run] <app> [<parameters>]
+                  [--settings-file=<filename>] [--enable-structured-logging]
+                  [--enable-tcp-command-server=<listeningPort>]
+                  [--dry-run] <app> [<parameters>]
   DESCRIPTION
                 Start the application selected via <app>.
 


### PR DESCRIPTION
- Fix duplicate github:// scheme in dependency how-to code snippet
- Correct docs/tutorial/ and docs/explanation/ folder names in CONTRIBUTING.md (were incorrectly using plural form)
- Add missing --enable-structured-logging and --enable-tcp-command-server options to the launchpad start -h synopsis example in the CLI reference