### PR TITLE
feat(docker): support LOG_FORMAT and SETTINGS_FILE env vars in GS64

### DIFF
--- a/.docker/gs64/docker-tests.sh
+++ b/.docker/gs64/docker-tests.sh
@@ -101,6 +101,7 @@ docker buildx build --tag launchpad-gs64:sut docker/gs64-"$GS64_VERSION"
    --file .docker/gs64/Dockerfile \
    .
 
+EXTRA_DOCKER_OPTIONS=()
 function run_launchpad_gem(){
   executeWithArguments docker run \
   -e TZ="America/Argentina/Buenos_Aires" \
@@ -108,12 +109,21 @@ function run_launchpad_gem(){
   --cap-add=SYS_RESOURCE \
   --network=launchpad-net \
   --volume="$PWD"/.docker/gs64/gem.conf:/opt/gemstone/conf/gem.conf \
+  "${EXTRA_DOCKER_OPTIONS[@]}" \
   launchpad-examples-gs64:sut "$@"
 }
 
 print_info "Running basic test"
 run_launchpad_gem
 assertOutputIncludesMessage '[INFO]' out
+assertOutputIncludesMessage "Hi Mr. DJ!" out
+print_success "OK"
+
+print_info "Running basic test with structured logging"
+EXTRA_DOCKER_OPTIONS=(-e LAUNCHPAD__LOG_FORMAT=json)
+run_launchpad_gem
+EXTRA_DOCKER_OPTIONS=()
+assertOutputIncludesMessage '"level":"INFO"' out
 assertOutputIncludesMessage "Hi Mr. DJ!" out
 print_success "OK"
 
@@ -149,6 +159,15 @@ print_success " Just name, OK"
 run_launchpad_gem launchpad start greeter --name=Julia --title=Miss
 assertOutputIncludesMessage "Hi Miss Julia!" out
 print_success " Name and title, OK"
+SETTINGS_FILE=$(mktemp --suffix=.ini)
+echo "name = Maria" > "$SETTINGS_FILE"
+chmod +r "$SETTINGS_FILE"
+EXTRA_DOCKER_OPTIONS=(-v "$SETTINGS_FILE:/tmp/settings.ini" -e LAUNCHPAD__SETTINGS_FILE=/tmp/settings.ini)
+run_launchpad_gem launchpad start greeter
+EXTRA_DOCKER_OPTIONS=()
+rm -f "$SETTINGS_FILE"
+assertOutputIncludesMessage "Hi Maria!" out
+print_success " Just name via settings file env var, OK"
 run_launchpad_gem launchpad start greeter --title=Miss
 assertOutputIncludesMessage "\[ERROR\] \"Name\" parameter not provided. You must provide one." err
 print_success " Missing name, OK"

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,3 +1,6 @@
 {
-  "MD013": false
+  "MD013": false,
+  "MD024": {
+    "siblings_only": true
+  }
 }

--- a/docker/gs64-3.7.1/launchpad
+++ b/docker/gs64-3.7.1/launchpad
@@ -42,6 +42,23 @@ fi
 # list GemStone services
 gslist -cvl >> "${GEMSTONE_LOG_DIR}/startnetldi.log"
 
-topaz -l -q -I "${LAUNCHPAD_TOPAZ_SCRIPT}" -S "${GEMSTONE_GLOBAL_DIR}/command-line-handler.tpz" -- launchpad "$@" &
+# Translate Launchpad environment variables into start command options
+EXTRA_ARGS=()
+if [[ "$LAUNCHPAD__LOG_FORMAT" == "json" ]]; then
+    EXTRA_ARGS+=(--enable-structured-logging)
+fi
+if [[ -n "$LAUNCHPAD__SETTINGS_FILE" ]]; then
+    EXTRA_ARGS+=("--settings-file=$LAUNCHPAD__SETTINGS_FILE")
+fi
+
+# These options are only valid for the start command and must precede the <app>
+# argument, so inject them right after the start subcommand
+LAUNCHPAD_ARGS=("$@")
+if [[ "${1:-}" == "start" ]]; then
+    shift
+    LAUNCHPAD_ARGS=(start "${EXTRA_ARGS[@]}" "$@")
+fi
+
+topaz -l -q -I "${LAUNCHPAD_TOPAZ_SCRIPT}" -S "${GEMSTONE_GLOBAL_DIR}/command-line-handler.tpz" -- launchpad "${LAUNCHPAD_ARGS[@]}" &
 pid="$!"
 wait "$pid"

--- a/docs/reference/Docker.md
+++ b/docs/reference/Docker.md
@@ -62,3 +62,10 @@ CMD [ "launchpad", "start", "app-name" , "--parameter=value" ]
 
 > Note that `ghcr.io/ba-st/launchpad-gs64` packages are deprecated and not receiving
 > more updates. Use `ghcr.io/ba-st/launchpad-gs64-3.7.1` instead.
+
+### Environment variables
+
+- `LAUNCHPAD__LOG_FORMAT` can be set to `json` to enable structured logging.
+- `LAUNCHPAD__SETTINGS_FILE` defines the path to a settings file to load for
+  application configuration. Supports INI and JSON formats (see the
+  [configuration reference](Configuration.md) for details).


### PR DESCRIPTION
Bring the GS64 Docker launchpad script on par with the Pharo one by translating the LAUNCHPAD__LOG_FORMAT and LAUNCHPAD__SETTINGS_FILE environment variables into the corresponding start command options. Since these options must precede the <app> argument, they are injected right after the start subcommand.

Also add matching Docker integration tests and document the supported environment variables in the GS64 section of the Docker reference.